### PR TITLE
[Fix] Update introduction pages with absolute links.

### DIFF
--- a/documentation/guides/introduction/00_getting_started.md
+++ b/documentation/guides/introduction/00_getting_started.md
@@ -19,13 +19,13 @@ import FeatureCard from '@site/src/components/FeatureCard';
 <FeatureCard
   title="🚀 Quick Start"
   description="Build a Leo program and deploy it to Aleo."
-  link="./quick_start"
+  link="/guides/introduction/quick_start"
 />
 
 <FeatureCard
   title="🦁 Local Setup"
   description="Setup a local development environment."
-  link="./installation"
+  link="/guides/introduction/installation"
 />
 
 </div>


### PR DESCRIPTION
## Motivation

The last PR had relative links in the feature cards, this PR updates them to absolute links so that they correct link.